### PR TITLE
feat: Add Brave Search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Brave Search, DuckDuckGo, Google
 ## How it Works
 
 ### Brave Search
-We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL.
+We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL. We also remove the Answer with AI button in the search bar next to the search icon.
 
 ### DuckDuckGo
 We disable DuckDuckGo's AI Assist by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Brave Search, DuckDuckGo, Google
 ## How it Works
 
 ### Brave Search
-We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL. We also remove the Answer with AI button in the search bar next to the search icon.
+We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL. We also remove the Answer with AI button in the search bar next to the search icon, and the Answer with AI search suggestion.
 
 ### DuckDuckGo
 We disable DuckDuckGo's AI Assist by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Brave Search, DuckDuckGo, Google
 We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL. We also remove the Answer with AI button in the search bar next to the search icon, and the Answer with AI search suggestion.
 
 ### DuckDuckGo
-We disable DuckDuckGo's AI Assist by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.
+We disable DuckDuckGo's `AI Assist` by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.
 
 ### Google
-We disable Google's AI Overview by adding the `udm=14` parameter to the default Google search URLs. This tells Google to switch to their 'Web' view which is a stripped down results page without AI Overviews or instant answers.
+We disable Google's `AI Overview` by adding the `udm=14` parameter to the default Google search URLs. This tells Google to switch to their 'Web' view which is a stripped down results page without AI Overviews or instant answers.
 
 ## Chrome Installation instructions
 1. Download the `src` folder from this github repo
@@ -30,7 +30,7 @@ We disable Google's AI Overview by adding the `udm=14` parameter to the default 
 6. Pin the extension to the Toolbar
 
 ## Troubleshooting
-If you don't see AI features being disabled then you might be using another extension that sets browser blocking or redirect rules for Google or DuckDuckGo. Only one rule can run on a page, so their rule might be running.
+If you don't see AI features being disabled then you might be using another extension that sets browser blocking or redirect rules for the URL you are accessing. Only one rule can run on a page, so their rule might be running.
 
 ## Future Updates
 Disable AI results in Bing (if possible).

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ This is a browser extension to disable AI features on various sites and search e
 Our goal is not to just hide AI-powered results on websites and search engines like other extensions, but to actually stop the browser or server requests that run behind the scenes. Otherwise resources are still consumed by AI to generate results, even if they are hidden visually.
 
 **Search Engines Supported:**  
-DuckDuckGo, Google
+Brave Search, DuckDuckGo, Google
 
 ## How to Install
 - Firefox and Firefox for Android: [Official Firefox Add-ons link](https://addons.mozilla.org/en-US/firefox/addon/disable-ai/)
 - Chrome Web Store link coming soon  
 
 ## How it Works
+
+### Brave Search
+We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL.
 
 ### DuckDuckGo
 We disable DuckDuckGo's AI Assist by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.

--- a/src/README.md
+++ b/src/README.md
@@ -15,4 +15,4 @@ We disable DuckDuckGo's `AI Assist` by adding the `assist=false` and `kbe=0` url
 We disable Google's `AI Overview` by adding the `udm=14` parameter to the default Google search URLs. This tells Google to switch to their 'Web' view which is a stripped down results page without AI Overviews or instant answers.
 
 ## Troubleshooting
-If you don't see AI features being disabled then you might be using another extension that sets browser blocking or redirect rules for Google or DuckDuckGo. Only one rule can run on a page, so their rule might be running.
+If you don't see AI features being disabled then you might be using another extension that sets browser blocking or redirect rules for the URL you are accessing. Only one rule can run on a page, so their rule might be running.

--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@ Our goal is not to just hide AI-powered results on websites and search engines l
 ## Search Engine Support
 
 ### Brave Search
-We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL.
+We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL. We also remove the Answer with AI button in the search bar next to the search icon, and the Answer with AI search suggestion.
 
 ### DuckDuckGo
 We disable DuckDuckGo's `AI Assist` by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.

--- a/src/README.md
+++ b/src/README.md
@@ -5,11 +5,14 @@ Our goal is not to just hide AI-powered results on websites and search engines l
 
 ## Search Engine Support
 
+### Brave Search
+We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL.
+
 ### DuckDuckGo
-We disable DuckDuckGo's AI Assist by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.
+We disable DuckDuckGo's `AI Assist` by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.
 
 ### Google
-We disable Google's AI Overview by adding the `udm=14` parameter to the default Google search URLs. This tells Google to switch to their 'Web' view which is a stripped down results page without AI Overviews or instant answers.
+We disable Google's `AI Overview` by adding the `udm=14` parameter to the default Google search URLs. This tells Google to switch to their 'Web' view which is a stripped down results page without AI Overviews or instant answers.
 
 ## Troubleshooting
 If you don't see AI features being disabled then you might be using another extension that sets browser blocking or redirect rules for Google or DuckDuckGo. Only one rule can run on a page, so their rule might be running.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,6 +27,19 @@
       }
     ]
   },
+  "content_scripts": [
+    {
+      "matches": [ "https://search.brave.com/", "https://search.brave.com/search*" ],
+      "css": [ "styles/brave_search.css" ],
+      "run_at": "document_start"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": [ "styles/brave_search.css"],
+      "matches": [ "https://search.brave.com/", "https://search.brave.com/search*" ]
+    }
+  ],
   "permissions": [
     "declarativeNetRequest",
     "declarativeNetRequestWithHostAccess"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Disable AI",
-  "version": "1.2.1",
+  "version": "1.3",
   "manifest_version": 3,
   "author": "jruns",
   "description": "Don't just hide results. Disable AI overviews on Google and DuckDuckGo so your searches consume less energy and water.",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,6 +32,7 @@
     "declarativeNetRequestWithHostAccess"
   ],
   "host_permissions": [
+    "*://search.brave.com/search*",
     "*://duckduckgo.com/*",
     "*://www.google.com/search*",
     "*://www.google.ad/search*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,7 +37,7 @@
   "web_accessible_resources": [
     {
       "resources": [ "styles/brave_search.css"],
-      "matches": [ "https://search.brave.com/", "https://search.brave.com/search*" ]
+      "matches": [ "https://search.brave.com/*" ]
     }
   ],
   "permissions": [

--- a/src/rules/redirect_rules.json
+++ b/src/rules/redirect_rules.json
@@ -84,5 +84,25 @@
           "urlFilter": "https://duckduckgo.com/*q=*",
           "resourceTypes": ["main_frame"]
         }
+      },
+      {
+        "id": 6,
+        "priority": 3,
+        "action": {
+          "type": "redirect",
+          "redirect": {
+              "transform": {
+                  "queryTransform": {
+                      "addOrReplaceParams": [
+                        { "key": "summary", "value": "0" }
+                      ]
+                  }
+              }
+          }
+        },
+        "condition": {
+          "urlFilter": "||search.brave.com/search",
+          "resourceTypes": ["main_frame"]
+        }
       }
   ]

--- a/src/rules/redirect_rules.json
+++ b/src/rules/redirect_rules.json
@@ -87,7 +87,7 @@
       },
       {
         "id": 6,
-        "priority": 3,
+        "priority": 1,
         "action": {
           "type": "redirect",
           "redirect": {

--- a/src/styles/brave_search.css
+++ b/src/styles/brave_search.css
@@ -1,0 +1,3 @@
+.subutton-wrapper:has(.ai-generate-icon) {
+    display: none;
+}

--- a/src/styles/brave_search.css
+++ b/src/styles/brave_search.css
@@ -1,3 +1,9 @@
+/* Hide AI search bar button */
 .subutton-wrapper:has(.ai-generate-icon) {
+    display: none;
+}
+
+/* Hide autocomplete AI suggestion */
+button.suggestion:has(.ai-generate) {
     display: none;
 }


### PR DESCRIPTION
Add Brave Search support
- Set `summary=0` on https://search.brave.com/search urls to disable the `Answer with AI` feature.
- Add a css file to https://search.brave.com/ and https://search.brave.com/search that hides the `Answer with AI` button in the search bar.