### PR TITLE
feat: Add Qwant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a browser extension to disable AI features on various sites and search e
 Our goal is not to just hide AI-powered results on websites and search engines like other extensions, but to actually stop the browser or server requests that run behind the scenes. Otherwise resources are still consumed by AI to generate results, even if they are hidden visually.
 
 **Search Engines Supported:**  
-Brave Search, DuckDuckGo, Ecosia, Google
+Brave Search, DuckDuckGo, Ecosia, Google, Qwant
 
 ## How to Install
 - Firefox and Firefox for Android: [Official Firefox Add-ons link](https://addons.mozilla.org/en-US/firefox/addon/disable-ai/)
@@ -23,6 +23,9 @@ We disable Ecosia's `AI Overview` by blocking the AI Overview data request to th
 
 ### Google
 We disable Google's `AI Overview` by adding the `udm=14` parameter to the default Google search URLs. This tells Google to switch to their 'Web' view which is a stripped down results page without AI Overviews or instant answers. We also hide the `AI Mode` button on the homepage and the `AI Mode` tab in the search bar on results pages.
+
+### Qwant
+We disable Qwant's `Flash Answer` by adding the `llm=0` parameter to the default Qwant All/Web search URLs. This disables the AI overview in regions where it is active and removes the AI summarize buttons next to search results.
 
 ## Troubleshooting
 If you don't see AI features being disabled then you might be using another extension that sets browser blocking or redirect rules for the URL you are accessing. Only one rule can run on a page, so their rule might be running.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Brave Search, DuckDuckGo, Ecosia, Google, Qwant
 We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL. We also hide the `Answer with AI` button in the search bar next to the search icon, and the Answer with AI search suggestion.
 
 ### DuckDuckGo
-We disable DuckDuckGo's `AI Assist` by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.
+We disable DuckDuckGo's `AI Assist` by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter. And we hide AI images from the Images search by adding the `kbj=1` url parameter
 
 ### Ecosia
 We disable Ecosia's `AI Overview` by blocking the AI Overview data request to their API. We also hide the `AI Chat` tab under the search bar.

--- a/src/README.md
+++ b/src/README.md
@@ -17,5 +17,8 @@ We disable Ecosia's `AI Overview` by blocking the AI Overview data request to th
 ### Google
 We disable Google's `AI Overview` by adding the `udm=14` parameter to the default Google search URLs. This tells Google to switch to their 'Web' view which is a stripped down results page without AI Overviews or instant answers. We also hide the `AI Mode` button on the homepage and the `AI Mode` tab in the search bar on results pages.
 
+### Qwant
+We disable Qwant's `Flash Answer` by adding the `llm=0` parameter to the default Qwant All/Web search URLs. This disables the AI overview in regions where it is active and removes the AI summarize buttons next to search results.
+
 ## Troubleshooting
 If you don't see AI features being disabled then you might be using another extension that sets browser blocking or redirect rules for the URL you are accessing. Only one rule can run on a page, so their rule might be running.

--- a/src/README.md
+++ b/src/README.md
@@ -9,7 +9,7 @@ Our goal is not to just hide AI-powered results on websites and search engines l
 We disable Brave Search's `Answer with AI` by adding the `summary=0` url parameter to the main Brave Search URL. We also hide the `Answer with AI` button in the search bar next to the search icon, and the Answer with AI search suggestion.
 
 ### DuckDuckGo
-We disable DuckDuckGo's `AI Assist` by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter.
+We disable DuckDuckGo's `AI Assist` by adding the `assist=false` and `kbe=0` url parameter to all DuckDuckGo search URLs. This tells DuckDuckGo to disable the AI Assist feature. We also turn off Duck.ai Chat by adding the `kbg=-1` url parameter. And we hide AI images from the Images search by adding the `kbj=1` url parameter
 
 ### Ecosia
 We disable Ecosia's `AI Overview` by blocking the AI Overview data request to their API. We also hide the `AI Chat` tab under the search bar.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Disable AI",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "manifest_version": 3,
   "author": "jruns",
   "description": "Don't just hide results. Disable AI overviews on popular search engines so your searches consume less energy and water.",
@@ -263,7 +263,8 @@
     "*://www.google.co.za/search*",
     "*://www.google.co.zm/search*",
     "*://www.google.co.zw/search*",
-    "*://www.google.cat/search*"
+    "*://www.google.cat/search*",
+    "*://www.qwant.com/*"
   ],
   "icons": {
     "16": "icons/icon_16.png",

--- a/src/rules/redirect_rules.json
+++ b/src/rules/redirect_rules.json
@@ -52,7 +52,8 @@
                       "addOrReplaceParams": [
                         { "key": "assist", "value": "false" },
                         { "key": "kbe", "value": "0" },
-                        { "key": "kbg", "value": "-1" }
+                        { "key": "kbg", "value": "-1" },
+                        { "key": "kbj", "value": "1" }
                       ]
                   }
               }
@@ -74,7 +75,8 @@
                       "addOrReplaceParams": [
                         { "key": "assist", "value": "false" },
                         { "key": "kbe", "value": "0" },
-                        { "key": "kbg", "value": "-1" }
+                        { "key": "kbg", "value": "-1" },
+                        { "key": "kbj", "value": "1" }
                       ]
                   }
               }

--- a/src/rules/redirect_rules.json
+++ b/src/rules/redirect_rules.json
@@ -104,5 +104,25 @@
           "urlFilter": "||search.brave.com/search",
           "resourceTypes": ["main_frame"]
         }
+      },
+      {
+        "id": 7,
+        "priority": 1,
+        "action": {
+          "type": "redirect",
+          "redirect": {
+              "transform": {
+                  "queryTransform": {
+                      "addOrReplaceParams": [
+                        { "key": "llm", "value": "0" }
+                      ]
+                  }
+              }
+          }
+        },
+        "condition": {
+          "urlFilter": "||www.qwant.com/*t=web*",
+          "resourceTypes": ["main_frame"]
+        }
       }
   ]


### PR DESCRIPTION
## Description
- Disable AI overviews on Qwant All/Web searches. They are currently only seen when the user's region is set to France.
- Hide AI images from DuckDuckGo's image search

## Related issues:
[Qwant - Issue #7](https://github.com/jruns/disable-ai/issues/7)